### PR TITLE
Improve download speed if System.Net.WebClient is available for RSAT installer

### DIFF
--- a/Scripts/Install-Win10RSATTools.ps1
+++ b/Scripts/Install-Win10RSATTools.ps1
@@ -54,15 +54,23 @@ param()
     Write-Verbose -Message "Now Downloading RSAT Tools installer"
 
     $Filename = $version.Split('/')[-1]
-    Invoke-WebRequest -Uri $version -UseBasicParsing -OutFile "$env:TEMP\$Filename" 
+    $OutputFile = "$env:TEMP\$Filename"
+
+    $DotNetDownloader = New-Object System.Net.WebClient
+    if ($DotNetDownloader -and $DotNetDownloader.DownloadFile) {
+        $DotNetDownloader.DownloadFile($version, $OutputFile)
+    }
+    else {
+        Invoke-WebRequest -Uri $version -UseBasicParsing -OutFile "$OutputFile" 
+    }
     
     Write-Verbose -Message "Starting the Windows Update Service to install the RSAT Tools "
     
-    Start-Process -FilePath wusa.exe -ArgumentList "$env:TEMP\$Filename /quiet" -Wait -Verbose
+    Start-Process -FilePath wusa.exe -ArgumentList "$OutputFile /quiet" -Wait -Verbose
     
     Write-Verbose -Message "RSAT Tools are now be installed"
     
-    Remove-Item "$env:TEMP\$Filename" -Verbose
+    Remove-Item $OutputFile -Verbose
     
     Write-Verbose -Message "Script Cleanup complete"
     

--- a/Scripts/Install-Win10RSATTools.ps1
+++ b/Scripts/Install-Win10RSATTools.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.0.0
+.VERSION 1.1.0
 
 .GUID 0b6b6733-a339-401a-b804-d107534bca0e
 
@@ -38,43 +38,22 @@
 #Requires -Version 5.0 -RunAsAdministrator
 [Cmdletbinding()]
 param()
-
     $VerbosePreference = 'Continue'
-
     $x86 = 'https://download.microsoft.com/download/1/D/8/1D8B5022-5477-4B9A-8104-6A71FF9D98AB/WindowsTH-RSAT_WS2016-x86.msu'
     $x64 = 'https://download.microsoft.com/download/1/D/8/1D8B5022-5477-4B9A-8104-6A71FF9D98AB/WindowsTH-RSAT_WS2016-x64.msu'
-
     switch ($env:PROCESSOR_ARCHITECTURE)
     {
         'x86' {$version = $x86}
         'AMD64' {$version = $x64}
     }
-
     Write-Verbose -Message "OS Version is $env:PROCESSOR_ARCHITECTURE"
     Write-Verbose -Message "Now Downloading RSAT Tools installer"
-
     $Filename = $version.Split('/')[-1]
     $OutputFile = "$env:TEMP\$Filename"
-
-    $DotNetDownloader = New-Object System.Net.WebClient
-    if ($DotNetDownloader -and $DotNetDownloader.DownloadFile) {
-        $DotNetDownloader.DownloadFile($version, $OutputFile)
-    }
-    else {
-        Invoke-WebRequest -Uri $version -UseBasicParsing -OutFile "$OutputFile" 
-    }
-    
-    Write-Verbose -Message "Starting the Windows Update Service to install the RSAT Tools "
-    
+    $WebClient = New-Object System.Net.WebClient
+    $WebClient.DownloadFile($version, $OutputFile)
+    Write-Verbose -Message "Starting the Windows Update Service to install the RSAT Tools"
     Start-Process -FilePath wusa.exe -ArgumentList "$OutputFile /quiet" -Wait -Verbose
-    
     Write-Verbose -Message "RSAT Tools are now be installed"
-    
     Remove-Item $OutputFile -Verbose
-    
     Write-Verbose -Message "Script Cleanup complete"
-    
-    Write-Verbose -Message "Remote Administration"
-
-
-       


### PR DESCRIPTION
I've had to run the RSAT installer script multiple times and noticed the download speed. To improve the speed I changed the slow Invoke-WebRequest with System.Net.WebClient if its available. This drastically reduces the time to download. This does however not show a progress indicator. If that's an issue, the Start-BitsTransfer cmdlet might be an option as it does show progress and is still significantly faster, the same with curl.exe which is included in the newer W10 versions.

It would be great if this could be looked at and merged. Please let me know if you have any questions or need me to change change anything.